### PR TITLE
Add a Twig extension to expose the RuntimeConfig.

### DIFF
--- a/Resources/config/service.xml
+++ b/Resources/config/service.xml
@@ -6,6 +6,7 @@
     <parameters>
         <parameter key="opensky.runtime_config.class">OpenSky\Bundle\RuntimeConfigBundle\Service\RuntimeParameterBag</parameter>
         <parameter key="opensky.runtime_config.logger.class">OpenSky\Bundle\RuntimeConfigBundle\Service\RuntimeParameterBagLogger</parameter>
+        <parameter key="opensky.runtime_config.twig.class">OpenSky\Bundle\RuntimeConfigBundle\Twig\Extension\RuntimeConfigExtension</parameter>
         <parameter key="opensky.runtime_config.logger.level">debug</parameter>
     </parameters>
 
@@ -19,6 +20,11 @@
             <argument>%opensky.runtime_config.logger.level%</argument>
             <argument type="service" id="logger" on-invalid="null" />
             <tag name="monolog.logger" channel="opensky.runtime_config" />
+        </service>
+
+        <service id="opensky.runtime_config.twig" class="%opensky.runtime_config.twig.class%">
+            <argument type="service" id="opensky.runtime_config" />
+            <tag name="twig.extension" />
         </service>
     </services>
 

--- a/Twig/Extension/RuntimeConfigExtension.php
+++ b/Twig/Extension/RuntimeConfigExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace OpenSky\Bundle\RuntimeConfigBundle\Twig\Extension;
+
+use OpenSky\Bundle\RuntimeConfigBundle\Service\RuntimeParameterBag;
+
+class RuntimeConfigExtension extends \Twig_Extension
+{
+    protected $runtimeConfig;
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $container
+     */
+    public function __construct(RuntimeParameterBag $runtimeConfig)
+    {
+        $this->runtimeConfig = $runtimeConfig;
+    }
+
+    /**
+     * Returns a list of global functions to add to the existing list.
+     *
+     * @return array An array of global functions
+     */
+    public function getFunctions()
+    {
+        return array(
+            'runtime_config' => new \Twig_Function_Method($this, 'getRuntimeConfig'),
+        );
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'runtime_config';
+    }
+
+    public function getRuntimeConfig($name)
+    {
+        return $this->runtimeConfig->get($name);
+    }
+}


### PR DESCRIPTION
I wrote a test case for this, but couldn't figure out how to make it run without a local instance of the entire Twig library. What's the best way to include the test?
