### PR TITLE
Catch missing parameter exceptions thrown by containers

### DIFF
--- a/Twig/Extension/RuntimeConfigExtension.php
+++ b/Twig/Extension/RuntimeConfigExtension.php
@@ -47,6 +47,8 @@ class RuntimeConfigExtension extends \Twig_Extension
             return $this->runtimeConfig->get($name);
         } catch (ParameterNotFoundException $e) {
             return null;
+        } catch (\InvalidArgumentException $e) {
+            return null;
         }
     }
 }


### PR DESCRIPTION
While `Container` objects throw `ParameterNotFoundException` exceptions containers that are built and cached override the `getParameter` method and, instead, throw `\InvalidArgumentException` exceptions. We want to catch both of them here.
