### PR TITLE
fix isset optimization

### DIFF
--- a/Service/RuntimeParameterBag.php
+++ b/Service/RuntimeParameterBag.php
@@ -59,7 +59,7 @@ class RuntimeParameterBag extends FrozenParameterBag implements ContainerAwareIn
     {
         $this->initialize();
 
-        if (!isset($array[$name]) && !array_key_exists($name, $this->parameters)) {
+        if (!isset($this->parameters[$name]) && !array_key_exists($name, $this->parameters)) {
             if ($this->container) {
                 return $this->container->getParameter($name);
             }


### PR DESCRIPTION
$array does not exist
the isset optimization will always fail and defer to the slower array_key_exists