### PR TITLE
Fix deprecations for twig 3

### DIFF
--- a/Service/RuntimeParameterBagLogger.php
+++ b/Service/RuntimeParameterBagLogger.php
@@ -20,9 +20,8 @@ class RuntimeParameterBagLogger
     /**
      * Constructor.
      *
-     * @param string          $level  Log level (should correspond to a logger method)
-     * @param LoggerInterface $logger Logger service
-     * @throws \InvalidArgumentException if level does not correspond to a method in LoggerInterface
+     * @param string $level Log level (should correspond to a logger method)
+     * @param LoggerInterface|null $logger Logger service
      */
     public function __construct($level, LoggerInterface $logger = null)
     {

--- a/Tests/Entity/ParameterRepositoryTest.php
+++ b/Tests/Entity/ParameterRepositoryTest.php
@@ -35,7 +35,7 @@ class ParameterRepositoryTest extends TestCase
     {
         $repository = $this->getMockBuilder(ParameterRepository::class)
             ->disableOriginalConstructor()
-            ->setMethods(['createQueryBuilder'])
+            ->onlyMethods(['createQueryBuilder'])
             ->getMock();
 
         $queryBuilder = $this->getMockBuilder('Doctrine\ORM\QueryBuilder')
@@ -44,18 +44,18 @@ class ParameterRepositoryTest extends TestCase
 
         $query = $this->getMockBuilder('Doctrine\ORM\AbstractQuery')
             ->disableOriginalConstructor()
-            ->setMethods(['getResult', 'getSQL', '_doExecute'])
+            ->onlyMethods(['getResult', 'getSQL', '_doExecute'])
             ->getMock();
 
         $query->expects($this->once())
             ->method('getResult')
             ->willReturn($queryResults);
 
-        $queryBuilder->expects($this->at(0))
+        $queryBuilder->expects($this->once())
             ->method('select')
             ->willReturn($queryBuilder);
 
-        $queryBuilder->expects($this->at(1))
+        $queryBuilder->expects($this->once())
             ->method('getQuery')
             ->willReturn($query);
 
@@ -66,7 +66,7 @@ class ParameterRepositoryTest extends TestCase
         $this->assertEquals($expectedParameters, $repository->getParametersAsKeyValueHash());
     }
 
-    public function provideQueryResultAndExpectedParameters()
+    public function provideQueryResultAndExpectedParameters(): array
     {
         return [
             [

--- a/Twig/Extension/RuntimeConfigExtension.php
+++ b/Twig/Extension/RuntimeConfigExtension.php
@@ -4,8 +4,10 @@ namespace OpenSky\Bundle\RuntimeConfigBundle\Twig\Extension;
 
 use OpenSky\Bundle\RuntimeConfigBundle\Service\RuntimeParameterBag;
 use Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class RuntimeConfigExtension extends \Twig_Extension
+class RuntimeConfigExtension extends AbstractExtension
 {
     protected $runtimeConfig;
 
@@ -24,21 +26,11 @@ class RuntimeConfigExtension extends \Twig_Extension
      *
      * @return array An array of global functions
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
-            new \Twig_SimpleFunction('runtime_config', [$this, 'getRuntimeConfig']),
+            new TwigFunction('runtime_config', [$this, 'getRuntimeConfig']),
         ];
-    }
-
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
-    {
-        return 'runtime_config';
     }
 
     public function getRuntimeConfig($name)

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,14 @@
     "homepage": "https://github.com/opensky/OpenSkyRuntimeConfigBundle",
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^7.1|^8.0",
+        "php": ">=7.1",
         "ext-json": "*",
         "doctrine/orm": "^2.4",
         "symfony/doctrine-bridge": "^3.0|^4.0|^5.0",
         "symfony/framework-bundle": "^3.0|^4.0|^5.0",
         "symfony/validator": "^3.0|^4.0|^5.0",
-        "symfony/yaml": "^3.0|^4.0|^5.0"
+        "symfony/yaml": "^3.0|^4.0|^5.0",
+        "twig/twig": "^2.13|^3.0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0"


### PR DESCRIPTION
As of Twig 2.11 then `Twig_Extension` class was marked as deprecated and replaced with `\Twig\Extension\ExtensionInterface` which was causing this package to block twig3 to be installed in newer Symfony installations. (5.4 tested).

The PR addresses the issue by extending the included new `AbstractExtension` class, updating the use of `TwigFunction` and removing `getName` which was deprecated in Twig 1.26.